### PR TITLE
Fix task output history display

### DIFF
--- a/app/pg_results.py
+++ b/app/pg_results.py
@@ -2,7 +2,7 @@ import streamlit as st
 from streamlit import session_state as ss
 from db_utils import delete_result, load_results
 from datetime import datetime
-from utils import rnd_id, format_result, generate_printable_view
+from utils import rnd_id, format_result, generate_printable_view, get_tasks_outputs_str
 
 class PageResults:
     def __init__(self):


### PR DESCRIPTION
## Summary
- fix missing import in results page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6863c0722b90833082faf3a05eccce8e