### PR TITLE
Improve task output readability

### DIFF
--- a/app/pg_results.py
+++ b/app/pg_results.py
@@ -86,11 +86,14 @@ class PageResults:
 
                 try:
                     tasks_output = result.result.get('tasks_output', None)
-                    tasks_output_str: list[str] = list(map(lambda t: t.get("raw", ""), tasks_output))
-
-                    tasks_result = get_tasks_outputs_str(tasks_output_str)
-                    formatted_tasks_result = format_result(tasks_result)
-                except:
+                    if tasks_output:
+                        tasks_output_str: list[str] = list(map(lambda t: t.get("raw", ""), tasks_output))
+                        tasks_descriptions = [t.get("description") for t in tasks_output]
+                        tasks_result = get_tasks_outputs_str(tasks_output_str, tasks_descriptions)
+                        formatted_tasks_result = format_result(tasks_result)
+                    else:
+                        formatted_tasks_result = ""
+                except Exception:
                     formatted_tasks_result = ""
 
                 # Show both rendered and raw versions using tabs

--- a/app/utils.py
+++ b/app/utils.py
@@ -161,9 +161,15 @@ def normalize_list_indentation(md_text: str) -> str:
     return "\n".join(normalized_lines)
 
 
-def get_tasks_outputs_str(tasks_output: list[TaskOutput | str]):
+def get_tasks_outputs_str(tasks_output: list[TaskOutput | str], tasks: list = None):
+    """Return a formatted string of task outputs, optionally including task descriptions."""
     strRes = ""
-    for task_output in tasks_output:
+    for idx, task_output in enumerate(tasks_output):
         val = task_output.raw if isinstance(task_output, TaskOutput) else task_output
-        strRes += f"\n\n#  TASK \n{val}\n\n==========\n"
+        desc = ""
+        if tasks and idx < len(tasks):
+            task = tasks[idx]
+            desc = getattr(task, "description", str(task))
+        title = f"#  TASK {desc}" if desc else "#  TASK"
+        strRes += f"\n\n{title}\n{val}\n\n==========\n"
     return strRes


### PR DESCRIPTION
## Summary
- include task descriptions when formatting task outputs
- store task description for results
- show task descriptions in runtime and saved results

## Testing
- `python -m py_compile app/utils.py app/pg_crew_run.py app/pg_results.py`

------
https://chatgpt.com/codex/tasks/task_b_6863c8b6dd908330a275be5f90d48b07