### PR TITLE
Fix unauthenticated RCE in MyCustomApiTool (GHSA-hm5m-fhf2-vrpq)

### DIFF
--- a/app/my_tools.py
+++ b/app/my_tools.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import os
+import ast
 from utils import rnd_id
 from crewai_tools import CodeInterpreterTool,ScrapeElementFromWebsiteTool,TXTSearchTool,SeleniumScrapingTool,PDFSearchTool,MDXSearchTool,JSONSearchTool,GithubSearchTool,EXASearchTool,DOCXSearchTool,CSVSearchTool,ScrapeWebsiteTool, FileReadTool, DirectorySearchTool, DirectoryReadTool, CodeDocsSearchTool, YoutubeVideoSearchTool,SerperDevTool,YoutubeChannelSearchTool,WebsiteSearchTool
 from tools.CSVSearchToolEnhanced import CSVSearchToolEnhanced
@@ -312,10 +313,27 @@ class MyCustomApiTool(MyTool):
         }
         super().__init__(tool_id, 'CustomApiTool', t('tool.custom_api_desc'), parameters, base_url=base_url, headers=headers, query_params=query_params)
 
+    @staticmethod
+    def _parse_headers(value):
+        if not value:
+            return None
+        if isinstance(value, dict):
+            parsed = value
+        else:
+            try:
+                parsed = ast.literal_eval(value)
+            except (SyntaxError, ValueError) as exc:
+                raise ValueError("headers must be a dictionary literal") from exc
+        if not isinstance(parsed, dict) or not all(
+            isinstance(k, str) and isinstance(v, str) for k, v in parsed.items()
+        ):
+            raise ValueError("headers must be a dictionary of string keys and values")
+        return parsed
+
     def create_tool(self) -> CustomApiTool:
         return CustomApiTool(
             base_url=self.parameters.get('base_url') if self.parameters.get('base_url') else None,
-            headers=eval(self.parameters.get('headers')) if self.parameters.get('headers') else None,
+            headers=self._parse_headers(self.parameters.get('headers')),
             query_params=self.parameters.get('query_params') if self.parameters.get('query_params') else None
         )
 


### PR DESCRIPTION
## Summary

Fixes the critical unauthenticated **Remote Code Execution** reported in GitHub Security Advisory [GHSA-hm5m-fhf2-vrpq](https://github.com/strnad/CrewAI-Studio/security/advisories/GHSA-hm5m-fhf2-vrpq) (CVSS 9.8, CWE-95).

`MyCustomApiTool.create_tool()` passed the user-supplied `headers` string straight into Python's `eval()`:

```python
headers=eval(self.parameters.get('headers')) if self.parameters.get('headers') else None,
```

Anyone able to reach the Streamlit UI (default port 8501, no auth layer) could put an arbitrary Python expression in the `headers` field of a Custom API Tool. It gets stored, then executed server-side when a crew runs, as `root` in the default Docker image. Full unauthenticated RCE.

## Fix

Replace `eval()` with `ast.literal_eval()` and validate the result is a `dict[str, str]`, rejecting anything else. `ast.literal_eval` only evaluates literals, so `__import__(...)`, function calls, etc. raise `ValueError` instead of executing.

The legitimate input format (`{'Authorization': 'Bearer ...'}`) is unchanged.

## Testing

- `py_compile` passes.
- Legit dict literal → parsed correctly.
- Empty value → `None` (unchanged behaviour).
- Payloads `__import__('os').system('id') or {}`, `{'a': __import__('os').getcwd()}`, `[1,2,3]` → all rejected with `ValueError`, no execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)