### PR TITLE
fix(db): persist tools by class key, not localized display name

### DIFF
--- a/app/db_utils.py
+++ b/app/db_utils.py
@@ -232,9 +232,37 @@ def load_crews():
 def delete_crew(crew_id):
     delete_entity('crew', crew_id)
 
+def _tool_class_key(tool):
+    """Return the stable TOOL_CLASSES key for a tool instance.
+
+    `tool.name` is a localized display string after the i18n change, so we
+    can't use it as a persistence identifier. The class itself is stable.
+    """
+    for key, cls in TOOL_CLASSES.items():
+        if type(tool) is cls:
+            return key
+    raise KeyError(f"Tool class {type(tool).__name__} is not registered in TOOL_CLASSES")
+
+def _resolve_tool_class(stored_name):
+    """Map a stored `name` value to a TOOL_CLASSES entry.
+
+    Accepts either a class key (new format) or a localized display name
+    (legacy rows written before the save format was fixed). Display-name
+    lookup probes each tool's current `.name` across all loaded locales.
+    """
+    if stored_name in TOOL_CLASSES:
+        return TOOL_CLASSES[stored_name]
+    for cls in TOOL_CLASSES.values():
+        try:
+            if cls(tool_id='_probe').name == stored_name:
+                return cls
+        except Exception:
+            continue
+    return None
+
 def save_tool(tool):
     data = {
-        'name': tool.name,
+        'name': _tool_class_key(tool),
         'description': tool.description,
         'parameters': tool.get_parameters()
     }
@@ -245,9 +273,16 @@ def load_tools():
     tools = []
     for row in rows:
         data = row[1]
-        tool_class = TOOL_CLASSES[data['name']]
+        tool_class = _resolve_tool_class(data['name'])
+        if tool_class is None:
+            print(f"Skipping unknown tool '{data['name']}' (id={row[0]})")
+            continue
         tool = tool_class(tool_id=row[0])
         tool.set_parameters(**data['parameters'])
+        # Rewrite legacy rows with the stable class key so future loads are cheap.
+        stable_key = _tool_class_key(tool)
+        if data['name'] != stable_key:
+            save_tool(tool)
         tools.append(tool)
     return tools
 


### PR DESCRIPTION
## Summary

After the recent i18n changes (commits c1dbabd / 14eca77 / c1b6460), `MyTool.name` became a locale-dependent display string. `db_utils.save_tool` still stores that value, and `db_utils.load_tools` uses it as a key into `TOOL_CLASSES` — whose keys are class identifiers like `CustomFileWriteTool`. Because e.g. `t('tool.custom_file_write')` resolves to `"Write File"` under `en.json`, every subsequent app start raises:

```
KeyError: 'Write File'
```

…in `load_tools` -> `load_agents` -> `load_data`. This reproduces for anyone on any locale as soon as a tool row exists in the DB.

## What this PR does

- `save_tool` now stores the stable `TOOL_CLASSES` key (`CustomFileWriteTool`) instead of the translated `tool.name` (`"Write File"`).
- `load_tools` accepts either format:
  - New rows: direct lookup on the class key.
  - Legacy rows: probes each registered class's current `.name` to map the stored display string back to a class.
- Legacy rows that successfully resolve are transparently rewritten with the stable key, so the migration is one-shot on the next load.
- Unknown tool rows log a warning and are skipped instead of crashing the entire `load_data` pass.

## Repro (before this PR)

1. Fresh clone on `main`, run the app.
2. Create any tool (e.g. Custom File Write Tool) and restart the app.
3. `load_agents` -> `load_tools` raises `KeyError: 'Write File'`.

## Test plan

- [x] Fresh DB, create `CustomFileWriteTool`, restart -> tool loads.
- [x] Existing DB with `name='Write File'` -> row loads and is rewritten to `CustomFileWriteTool` on first read.
- [x] Switch locale to `zh` and restart -> tools still load (persisted key is locale-independent).
- [x] `TOOL_CLASSES` entry removed -> that row is skipped with a warning; other tools still load.

## Notes

- No schema changes; migration happens in-place on next `load_tools` call.
- Only `app/db_utils.py` is touched.