### PR TITLE
Revert json_repair to 0.25.2 to fix pip resolution conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -76,7 +76,7 @@ Jinja2==3.1.6
 jiter==0.11.1
 jmespath==1.0.1
 json5==0.12.1
-json_repair==0.60.1
+json_repair==0.25.2
 jsonlines==4.0.0
 jsonpatch==1.33
 jsonpointer==3.0.0


### PR DESCRIPTION
Fixes #124.

**Root cause:** #121 bumped `json_repair` 0.25.2 → 0.60.1, but `crewai==1.5.0` hard-pins `json-repair==0.25.2`, making pip resolution impossible. Clean Docker builds have been broken since that merge.

`json_repair` had no Dependabot/security advisory, so the bump was unnecessary and reverting it loses nothing.

**Verified:**
- Reproduced the exact `ResolutionImpossible` error from #124 on current main
- Full `docker build` passes with this fix (arm64)
- Smoke test: container starts, Streamlit UI responds HTTP 200